### PR TITLE
do not try to read empty messages

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -267,6 +267,10 @@ static void handle_view_message(int argc, char **argv) {
 		set_status(account, ACCOUNT_ERROR, "Failed to read mailbox");
 		return;
 	}
+	if (!mbox->messages->length) {
+		set_status(account, ACCOUNT_ERROR, "Failed to read empty message");
+		return;
+	}
 	account->viewer.msg = mbox->messages->items[
 		mbox->messages->length - account->ui.selected_message - 1];
 	load_message_viewer(account);


### PR DESCRIPTION
otherwise we fail badly:
(gdb) bt
#0  0x000055555555fa2c in load_message_viewer (account=0x55555578ebf0) at /home/jenfi/WORK/jp/git/aerc/src/handlers.c:127
#1  0x000055555555d53e in handle_view_message (argc=0, argv=0x7ffff010e648) at /home/jenfi/WORK/jp/git/aerc/src/commands.c:272
#2  0x000055555555ded2 in handle_command (_exec=0x55555578ac10 "view-message") at /home/jenfi/WORK/jp/git/aerc/src/commands.c:484
#3  0x0000555555564fee in process_event (event=0x5555557bd270, event_queue=0x5555557bcfa0) at /home/jenfi/WORK/jp/git/aerc/src/ui.c:523
#4  0x0000555555565206 in ui_tick () at /home/jenfi/WORK/jp/git/aerc/src/ui.c:582
#5  0x0000555555560646 in main (argc=1, argv=0x7fffffffe5a8) at /home/jenfi/WORK/jp/git/aerc/src/main.c:141
