### PR TITLE
fix null pointer dereference in render_items

### DIFF
--- a/src/render.c
+++ b/src/render.c
@@ -243,7 +243,7 @@ void render_items(struct geometry geo) {
 		add_loading(geo);
 		return;
 	}
-	
+
 	if (account->selected && mailbox->messages->length == 0) {
 		geo.x += geo.width / 2 - strlen(config->ui.empty_message) / 2;
 		get_color("message-list-empty", &cell);
@@ -255,6 +255,9 @@ void render_items(struct geometry geo) {
 	for (int i = mailbox->messages->length - account->ui.list_offset - 1;
 			i >= 0 && geo.y < limit;
 			--i, ++geo.y) {
+		if ((size_t)i >= mailbox->messages->length) {
+			continue;
+		}
 		struct aerc_message *message = mailbox->messages->items[i];
 		const char *subject = get_message_header(message, "Subject");
 		worker_log(L_DEBUG, "Rendering message %d of %zd at %d (offs %zd) [%s]",


### PR DESCRIPTION
Thread 1 "aerc" received signal SIGSEGV, Segmentation fault.
0x00005555555631ae in get_message_header (msg=0x5555555bfe30, key=0x5555555723bf "Subject") at /home/jenfi/WORK/jp/git/aerc/src/state.c:103
103             for (size_t i = 0; i < msg->headers->length; ++i) {
(gdb) bt
#0  0x00005555555631ae in get_message_header (msg=0x5555555bfe30, key=0x5555555723bf "Subject") at /home/jenfi/WORK/jp/git/aerc/src/state.c:103
#1  0x00005555555629bb in render_items (geo=...) at /home/jenfi/WORK/jp/git/aerc/src/render.c:259
#2  0x0000555555564af6 in rerender_message_list () at /home/jenfi/WORK/jp/git/aerc/src/ui.c:174
#3  0x0000555555564d75 in rerender () at /home/jenfi/WORK/jp/git/aerc/src/ui.c:236
#4  0x0000555555565f9f in ui_tick () at /home/jenfi/WORK/jp/git/aerc/src/ui.c:621
#5  0x0000555555561239 in main (argc=1, argv=0x7fffffffe388) at /home/jenfi/WORK/jp/git/aerc/src/main.c:141

It is maybe more clear with this valgrind trace:
==26954== Thread 1:
==26954== Invalid read of size 8
==26954==    at 0x1169A1: render_items (render.c:258)
==26954==    by 0x118AF5: rerender_message_list (ui.c:174)
==26954==    by 0x118D74: rerender (ui.c:236)
==26954==    by 0x119F9E: ui_tick (ui.c:621)
==26954==    by 0x115238: main (main.c:141)
==26954==  Address 0x7ca1a20 is 32 bytes inside a block of size 48 free'd
==26954==    at 0x4C2FF9B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==26954==    by 0x117118: free_aerc_message (state.c:96)
==26954==    by 0x114859: handle_worker_message_updated (handlers.c:165)
==26954==    by 0x114DBD: handle_worker_message (main.c:56)
==26954==    by 0x115202: main (main.c:136)
==26954==  Block was alloc'd at
==26954==    at 0x4C31155: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==26954==    by 0x123A5D: serialize_message (worker.c:52)
==26954==    by 0x123EA4: serialize_mailbox (worker.c:108)
==26954==    by 0x123EF3: update_mailbox (worker.c:114)
==26954==    by 0x1219BA: imap_select_callback (select.c:47)
==26954==    by 0x122217: handle_imap_status (status.c:68)
==26954==    by 0x11FB01: handle_line (imap.c:77)
==26954==    by 0x120325: imap_receive (imap.c:178)
==26954==    by 0x124188: imap_worker (worker.c:168)
==26954==    by 0x4E42C62: start_thread (pthread_create.c:486)
==26954==    by 0x57779BE: clone (clone.S:95)
==26954==
==26954== Invalid read of size 8
==26954==    at 0x117139: get_message_header (state.c:100)
==26954==    by 0x1169BA: render_items (render.c:259)
==26954==    by 0x118AF5: rerender_message_list (ui.c:174)
==26954==    by 0x118D74: rerender (ui.c:236)
==26954==    by 0x119F9E: ui_tick (ui.c:621)
==26954==    by 0x115238: main (main.c:141)
==26954==  Address 0x4700000019 is not stack'd, malloc'd or (recently) free'd